### PR TITLE
Refactor implementation for (skipping) validation

### DIFF
--- a/pyam/_compare.py
+++ b/pyam/_compare.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pandas as pd
+
+
+def _compare(
+    left, right, left_label="left", right_label="right", drop_close=True, **kwargs
+):
+    """Internal implementation of comparison of IamDataFrames or pd.Series"""
+
+    def as_series(s):
+        return s if isinstance(s, pd.Series) else s._data
+
+    ret = pd.merge(
+        left=as_series(left).rename(index=left_label),
+        right=as_series(right).rename(index=right_label),
+        how="outer",
+        left_index=True,
+        right_index=True,
+    )
+    if drop_close:
+        ret = ret[~np.isclose(ret[left_label], ret[right_label], **kwargs)]
+    return ret

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2518,15 +2518,15 @@ def compare(
     """
     ret = pd.concat(
         {
-            right_label: right.data.set_index(right._LONG_IDX),
             left_label: left.data.set_index(left._LONG_IDX),
+            right_label: right.data.set_index(right._LONG_IDX),
         },
         axis=1,
     )
     ret.columns = ret.columns.droplevel(1)
     if drop_close:
         ret = ret[~np.isclose(ret[left_label], ret[right_label], **kwargs)]
-    return ret[[right_label, left_label]]
+    return ret
 
 
 def concat(dfs, ignore_meta_conflict=False, **kwargs):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -58,6 +58,7 @@ from pyam.utils import (
 )
 from pyam.read_ixmp import read_ix
 from pyam.plotting import PlotAccessor, mpl_args_to_meta_cols
+from pyam._compare import _compare
 from pyam._aggregate import (
     _aggregate,
     _aggregate_region,
@@ -2516,17 +2517,9 @@ def compare(
     kwargs : arguments for comparison of values
         passed to :func:`numpy.isclose`
     """
-    ret = pd.concat(
-        {
-            left_label: left.data.set_index(left._LONG_IDX),
-            right_label: right.data.set_index(right._LONG_IDX),
-        },
-        axis=1,
+    return _compare(
+        left, right, left_label="left", right_label="right", drop_close=True, **kwargs
     )
-    ret.columns = ret.columns.droplevel(1)
-    if drop_close:
-        ret = ret[~np.isclose(ret[left_label], ret[right_label], **kwargs)]
-    return ret
 
 
 def concat(dfs, ignore_meta_conflict=False, **kwargs):

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -687,7 +687,7 @@ class IamDataFrame(object):
 
         # assign data and other attributes
         ret._LONG_IDX = _index
-        ret._data = _data.set_index(ret._LONG_IDX)
+        ret._data = _data.set_index(ret._LONG_IDX).value
         ret.time_col = "year"
         ret._set_attributes()
         delattr(ret, "time")

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -2517,9 +2517,7 @@ def compare(
     kwargs : arguments for comparison of values
         passed to :func:`numpy.isclose`
     """
-    return _compare(
-        left, right, left_label="left", right_label="right", drop_close=True, **kwargs
-    )
+    return _compare(left, right, left_label, right_label, drop_close=True, **kwargs)
 
 
 def concat(dfs, ignore_meta_conflict=False, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,18 @@ REG_DF = pd.DataFrame(
 )
 
 
+RECURSIVE_DF = pd.DataFrame(
+    [
+        ["Secondary Energy|Electricity", "EJ/yr", 5, 19.0],
+        ["Secondary Energy|Electricity|Wind", "EJ/yr", 5, 17],
+        ["Secondary Energy|Electricity|Wind|Offshore", "EJ/yr", 1, 5],
+        ["Secondary Energy|Electricity|Wind|Onshore", "EJ/yr", 4, 12],
+        ["Secondary Energy|Electricity|Solar", "EJ/yr", np.nan, 2],
+    ],
+    columns=["variable", "unit"] + TEST_YEARS,
+)
+
+
 TEST_STACKPLOT_DF = pd.DataFrame(
     [
         ["World", "Emissions|CO2|Energy|Oil", "Mt CO2/yr", 2, 3.2, 2.0, 1.8],
@@ -207,6 +219,24 @@ def reg_df():
 @pytest.fixture(scope="session")
 def plot_df():
     df = IamDataFrame(data=os.path.join(TEST_DATA_DIR, "plot_data.csv"))
+    yield df
+
+
+# IamDataFrame with two scenarios and structure for recursive aggregation
+@pytest.fixture(scope="function", params=["year", "datetime"])
+def recursive_df(request):
+
+    data = (
+        RECURSIVE_DF
+        if request.param == "year"
+        else RECURSIVE_DF.rename(DTS_MAPPING, axis="columns")
+    )
+
+    df = IamDataFrame(data, model="model_a", scenario="scen_a", region="World")
+    df2 = df.rename(scenario={"scen_a": "scen_b"})
+    df2._data *= 2
+    df.append(df2, inplace=True)
+
     yield df
 
 

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -151,6 +151,11 @@ def test_aggregate_skip_intermediate(recursive_df):
     agg_vars = [f"{v}{i}" for i in ["", "|Wind"]]
     df_minimal.filter(variable=agg_vars, scenario="scen_b", keep=False, inplace=True)
 
+    # simply calling recursive aggregation raises an error
+    match = "Aggregated values are inconsistent with existing data:"
+    with pytest.raises(ValueError, match=match):
+        df_minimal.aggregate(variable=v, recursive=True, append=True)
+
     # append to `self` with skipping validation
     df_minimal.aggregate(variable=v, recursive="skip-validate", append=True)
     assert_iamframe_equal(df_minimal, recursive_df)

--- a/tests/test_feature_aggregate.py
+++ b/tests/test_feature_aggregate.py
@@ -42,17 +42,6 @@ PRICE_MAX_DF = pd.DataFrame(
     columns=LONG_IDX + ["value"],
 )
 
-RECURSIVE_DF = pd.DataFrame(
-    [
-        ["Secondary Energy|Electricity", "EJ/yr", 5, 19.0],
-        ["Secondary Energy|Electricity|Wind", "EJ/yr", 5, 17],
-        ["Secondary Energy|Electricity|Wind|Offshore", "EJ/yr", 1, 5],
-        ["Secondary Energy|Electricity|Wind|Onshore", "EJ/yr", 4, 12],
-        ["Secondary Energy|Electricity|Solar", "EJ/yr", np.nan, 2],
-    ],
-    columns=["variable", "unit"] + TEST_YEARS,
-)
-
 
 @pytest.mark.parametrize(
     "variable,data",
@@ -133,54 +122,38 @@ def test_aggregate_by_list_with_components_raises(simple_df):
     pytest.raises(ValueError, simple_df.aggregate, v, components=components)
 
 
-@pytest.mark.parametrize("time_col", (("year"), ("time")))
-def test_aggregate_recursive(time_col):
+def test_aggregate_recursive(recursive_df):
     # use the feature `recursive=True`
-    data = (
-        RECURSIVE_DF
-        if time_col == "year"
-        else RECURSIVE_DF.rename(DTS_MAPPING, axis="columns")
-    )
-    df = IamDataFrame(data, model="model_a", scenario="scen_a", region="World")
-    df2 = df.rename(scenario={"scen_a": "scen_b"})
-    df2._data *= 2
-    df.append(df2, inplace=True)
 
     # create object without variables to be aggregated
     v = "Secondary Energy|Electricity"
     agg_vars = [f"{v}{i}" for i in ["", "|Wind"]]
-    df_minimal = df.filter(variable=agg_vars, keep=False)
+    df_minimal = recursive_df.filter(variable=agg_vars, keep=False)
 
     # return recursively aggregated data as new object
     obs = df_minimal.aggregate(variable=v, recursive=True)
-    assert_iamframe_equal(obs, df.filter(variable=agg_vars))
+    assert_iamframe_equal(obs, recursive_df.filter(variable=agg_vars))
 
     # append to `self`
     df_minimal.aggregate(variable=v, recursive=True, append=True)
-    assert_iamframe_equal(df_minimal, df)
+    assert_iamframe_equal(df_minimal, recursive_df)
 
 
-@pytest.mark.parametrize("time_col", (("year"), ("time")))
-def test_aggregate_skip_intermediate(time_col):
-    # use the feature `recursive=skip-validate`
-    data = (
-        RECURSIVE_DF
-        if time_col == "year"
-        else RECURSIVE_DF.rename(DTS_MAPPING, axis="columns")
-    )
-    df = IamDataFrame(data, model="model_a", scenario="scen_a", region="World")
-    df2 = df.rename(scenario={"scen_a": "scen_b"})
-    df2._data *= 2
-    df.append(df2, inplace=True)
+def test_aggregate_skip_intermediate(recursive_df):
+    # make the data inconsistent, check (and then skip) validation
+
+    recursive_df._data.iloc[0] = recursive_df._data.iloc[0] + 2
+    recursive_df._data.iloc[3] = recursive_df._data.iloc[3] + 2
 
     # create object without variables to be aggregated, but with intermediate variables
     v = "Secondary Energy|Electricity"
-    agg_vars = [f"{v}{i}" for i in [""]]
-    df_minimal = df.filter(variable=agg_vars, scenario="scen_a", keep=False)
+    df_minimal = recursive_df.filter(variable=v, scenario="scen_a", keep=False)
+    agg_vars = [f"{v}{i}" for i in ["", "|Wind"]]
+    df_minimal.filter(variable=agg_vars, scenario="scen_b", keep=False, inplace=True)
 
-    # append to `self`
+    # append to `self` with skipping validation
     df_minimal.aggregate(variable=v, recursive="skip-validate", append=True)
-    assert_iamframe_equal(df_minimal, df)
+    assert_iamframe_equal(df_minimal, recursive_df)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_feature_compare.py
+++ b/tests/test_feature_compare.py
@@ -10,15 +10,15 @@ def test_compare(test_df):
     clone._data.iloc[0] = 2
     clone.rename(variable={"Primary Energy|Coal": "Primary Energy|Gas"}, inplace=True)
 
-    obs = compare(test_df, clone, right_label="test_df", left_label="clone")
+    obs = compare(test_df, clone, left_label="test_df", right_label="clone")
 
     exp = pd.DataFrame(
         [
-            ["Primary Energy", "EJ/yr", dt.datetime(2005, 6, 17), 2, 1],
-            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2005, 6, 17), np.nan, 0.5],
-            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2010, 7, 21), np.nan, 3],
-            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2005, 6, 17), 0.5, np.nan],
-            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2010, 7, 21), 3, np.nan],
+            ["Primary Energy", "EJ/yr", dt.datetime(2005, 6, 17), 1, 2],
+            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2005, 6, 17), 0.5, np.nan],
+            ["Primary Energy|Coal", "EJ/yr", dt.datetime(2010, 7, 21), 3, np.nan],
+            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2005, 6, 17), np.nan, 0.5],
+            ["Primary Energy|Gas", "EJ/yr", dt.datetime(2010, 7, 21), np.nan, 3],
         ],
         columns=["variable", "unit", "time", "test_df", "clone"],
     )


### PR DESCRIPTION
# Description of PR

While reviewing https://github.com/IAMconsortium/pyam/pull/532, I noticed that there was still a duplication of effort - first computing the aggregate values, then appending, then (optionally, true by default) again computing the aggregate values for the consistency evaluation.

This PR implements a more efficient approach: first compute the aggregate values, split them into two groups (already existing vs. new data), (optionally) perform the validation on existing data, then append the new data.

To do this efficiently, I moved the `compare` feature into a separate submodule and made it compatible with receiving a pd.Series directly.

Also, I moved the test data for the recursive aggregation feature into conftest.py to remove duplicate code, and I added an explicit assertion that calling the recursive aggregation with inconsistent data raises an error.
